### PR TITLE
Add support for logical assignment expression on class private field

### DIFF
--- a/packages/babel-helper-member-expression-to-functions/src/index.js
+++ b/packages/babel-helper-member-expression-to-functions/src/index.js
@@ -307,11 +307,19 @@ const handle = {
         // assignment.
         this.memoise(member, 2);
 
-        value = t.binaryExpression(
-          operator.slice(0, -1),
-          this.get(member),
-          value,
-        );
+        if (operator === "||=" || operator === "&&=" || operator === "??=") {
+          value = t.logicalExpression(
+            operator.slice(0, -1),
+            this.get(member),
+            value,
+          );
+        } else {
+          value = t.binaryExpression(
+            operator.slice(0, -1),
+            this.get(member),
+            value,
+          );
+        }
       }
 
       parentPath.replaceWith(this.set(member, value));

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/exec.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/exec.js
@@ -1,0 +1,36 @@
+class Foo {
+  #nullish = 0;
+  #and = 0;
+  #or = 0;
+
+  get () {
+    return {
+      nullish: this.#nullish,
+      and: this.#and,
+      or: this.#or,
+    };
+  }
+
+  setNullish (v) {
+    this.#nullish ??= v;
+  }
+
+  setAnd (v) {
+    this.#and &&= v;
+  }
+
+  setOr (v) {
+    this.#or ||= v;
+  }
+}
+
+const f = new Foo();
+
+f.setNullish(1);
+expect(f.get().nullish).toBe(0)
+
+f.setAnd(1);
+expect(f.get().and).toBe(0)
+
+f.setOr(1);
+expect(f.get().or).toBe(1)

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/input.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/input.js
@@ -1,0 +1,10 @@
+class Foo {
+  #foo = 0;
+
+  test(other) {
+    this.#foo ??= 1;
+    this.#foo = 2;
+    other.obj.#foo ??= 1;
+    other.obj.#foo = 2;
+  }
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/options.json
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/options.json
@@ -1,0 +1,7 @@
+{
+  "plugins": [
+    "proposal-logical-assignment-operators",
+    "proposal-class-properties",
+    "proposal-nullish-coalescing-operator"
+  ]
+}

--- a/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/output.js
+++ b/packages/babel-plugin-proposal-class-properties/test/fixtures/private/logical-assignment/output.js
@@ -1,0 +1,27 @@
+function _classPrivateFieldSet(receiver, privateMap, value) { var descriptor = privateMap.get(receiver); if (!descriptor) { throw new TypeError("attempted to set private field on non-instance"); } if (descriptor.set) { descriptor.set.call(receiver, value); } else { if (!descriptor.writable) { throw new TypeError("attempted to set read only private field"); } descriptor.value = value; } return value; }
+
+function _classPrivateFieldGet(receiver, privateMap) { var descriptor = privateMap.get(receiver); if (!descriptor) { throw new TypeError("attempted to get private field on non-instance"); } if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
+
+var _foo = new WeakMap();
+
+class Foo {
+  constructor() {
+    _foo.set(this, {
+      writable: true,
+      value: 0
+    });
+  }
+
+  test(other) {
+    var _other$obj, _classPrivateFieldGet2, _classPrivateFieldGet3;
+
+    _classPrivateFieldSet(this, _foo, (_classPrivateFieldGet2 = _classPrivateFieldGet(this, _foo)) !== null && _classPrivateFieldGet2 !== void 0 ? _classPrivateFieldGet2 : 1);
+
+    _classPrivateFieldSet(this, _foo, 2);
+
+    _classPrivateFieldSet(_other$obj = other.obj, _foo, (_classPrivateFieldGet3 = _classPrivateFieldGet(_other$obj, _foo)) !== null && _classPrivateFieldGet3 !== void 0 ? _classPrivateFieldGet3 : 1);
+
+    _classPrivateFieldSet(other.obj, _foo, 2);
+  }
+
+}


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

Please note that the Babel Team requires two approvals before merging most PRs.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #`11646
| Patch: Bug Fix?          | Yes
| Major: Breaking Change?  | No (isn't it?)
| Minor: New Feature?      | No
| Tests Added + Pass?      | Yes
| Documentation PR Link    | <!-- If only readme change, add `[skip ci]` to your commits -->
| Any Dependency Changes?  | No
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
This fixes the bug that logical assignment expression cannot be used on class private field.